### PR TITLE
add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+ARG PYVER=3.11 DEBVER=slim-bullseye
+
+
+FROM python:$PYVER-$DEBVER
+WORKDIR /app
+
+ARG USER=app
+ARG GROUP=$USER
+RUN addgroup --system "$GROUP" && adduser --system --ingroup "$GROUP" "$USER"
+
+COPY --chown=$USER:$GROUP requirements.txt .
+RUN pip install --no-cache-dir --upgrade -r requirements.txt
+
+USER $USER:$GROUP
+COPY --chown=$USER:$GROUP . .
+
+EXPOSE 8000
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
This uses Python version 3.11 with Debian slim-bullseye (11).

I tried for a quite while to build it on Alpine, but Zenroom bindings fail to work no matter what I do

It uses Uvicorn that listens on TCP over IPv4 using port 8000.

A process manager such as Gunicorn was excluded for simplicity and can be used separetely, or orchestration can be used instead.